### PR TITLE
세션 아이템 발표자 텍스트 오버플로우 문제 수정

### DIFF
--- a/lib/pages/track_screen.dart
+++ b/lib/pages/track_screen.dart
@@ -80,7 +80,7 @@ class TrackScreenState extends State<TrackScreen> {
             new Padding(padding: const EdgeInsets.symmetric(horizontal: 6.0)),
             new Flexible(
               child: new Container(
-                height: 60.0,
+                constraints: BoxConstraints(minHeight: 60.0),
                 child: new Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
스케쥴 화면의 세션 목록에 보면 제목이 두 줄인 경우 발표자 이름이 잘리는 경우가 있어서 해당 위젯의 고정된 높이값을 제외하고 대신 최소 높이를 적용하였습니다.

![Screenshot_2019-03-13-12-02-19](https://user-images.githubusercontent.com/6913297/54250722-43fc7c80-4588-11e9-9213-3a2c1e927354.png)
