### PR TITLE
세션 상세 화면 UI 수정

### DIFF
--- a/lib/pages/session_detail_dialog.dart
+++ b/lib/pages/session_detail_dialog.dart
@@ -33,30 +33,31 @@ class SessionDetailDialog extends ModalRoute<void> {
   ) {
     // This makes sure that text and other content follows the material style
     return GestureDetector(
-        child: Material(
-          type: MaterialType.transparency,
-          // make sure that the overlay content is not cut off
-          child: SafeArea(
-            child: new Stack(
-              children: <Widget>[
-                new Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: <Widget>[
-                    new Padding(
-                      padding: const EdgeInsets.all(27.0),
-                      child: new IconButton(
-                        icon: new Image.asset(Strings.SESSION_DIALOG_IMAGES_CLOSE),
-                        iconSize: 24,
-                        onPressed: () => Navigator.pop(context),
-                      ),
+      child: Material(
+        type: MaterialType.transparency,
+        // make sure that the overlay content is not cut off
+        child: SafeArea(
+          child: new Stack(
+            children: <Widget>[
+              new Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: <Widget>[
+                  new Padding(
+                    padding: const EdgeInsets.all(27.0),
+                    child: new IconButton(
+                      icon:
+                          new Image.asset(Strings.SESSION_DIALOG_IMAGES_CLOSE),
+                      iconSize: 24,
+                      onPressed: () => Navigator.pop(context),
                     ),
-                  ],
-                ),
-                _buildOverlayContent(context),
-              ],
-            ),
+                  ),
+                ],
+              ),
+              _buildOverlayContent(context),
+            ],
           ),
         ),
+      ),
       onTap: () => Navigator.pop(context),
     );
   }
@@ -67,50 +68,64 @@ class SessionDetailDialog extends ModalRoute<void> {
       mainAxisSize: MainAxisSize.max,
       children: <Widget>[
         new Center(
-          child: new Padding(
-            padding: const EdgeInsets.all(27.0),
-            child: GestureDetector(
-              child: new Container(
-                width: double.infinity,
-                decoration: new BoxDecoration(
-                  color: Colors.white,
-                  borderRadius: new BorderRadius.all(
-                    const Radius.circular(4.0),
-                  ),
-                ),
+          child: new Stack(
+            children: <Widget>[
+              new Padding(
                 padding: const EdgeInsets.only(
-                    left: 10.0, right: 10, top: 16, bottom: 35),
-                child: new Column(
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: <Widget>[
-                    profileImage,
-                    new Padding(
-                        padding: const EdgeInsets.only(
-                            left: 32.0, right: 32.0, top: 16.0, bottom: 3.0),
-                        child: new Text(
-                          sessionData.title,
-                          textAlign: TextAlign.center,
-                          style: new TextStyle(fontSize: 16.0),
-                        )),
-                    new Text(
-                      sessionData.name,
-                      style: new TextStyle(
-                          color: new Color(0xffa5b495), fontSize: 16.0),
+                    left: 27.0, right: 27.0, top: avatarHalfSize, bottom: 27.0),
+                child: GestureDetector(
+                    child: new Container(
+                      width: double.infinity,
+                      decoration: new BoxDecoration(
+                        color: Colors.white,
+                        borderRadius: new BorderRadius.all(
+                          const Radius.circular(4.0),
+                        ),
+                      ),
+                      padding: const EdgeInsets.only(
+                          left: 10.0,
+                          right: 10.0,
+                          top: avatarHalfSize,
+                          bottom: avatarHalfSize),
+                      child: new Column(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: <Widget>[
+                          new Padding(
+                              padding: const EdgeInsets.only(
+                                  left: 32.0,
+                                  right: 32.0,
+                                  top: 16.0,
+                                  bottom: 3.0),
+                              child: new Text(
+                                sessionData.title,
+                                textAlign: TextAlign.center,
+                                style: new TextStyle(fontSize: 16.0),
+                              )),
+                          new Text(
+                            sessionData.name,
+                            style: new TextStyle(
+                                color: new Color(0xffa5b495), fontSize: 16.0),
+                          ),
+                          new Padding(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 10.0, vertical: 13.0),
+                              child: new Text(
+                                sessionData.contents.toString(),
+                                style: new TextStyle(
+                                    color: new Color(0xff4a4a4a),
+                                    fontSize: 12.0),
+                              )),
+                          //rating
+                        ],
+                      ),
                     ),
-                    new Padding(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 10.0, vertical: 13.0),
-                        child: new Text(
-                          sessionData.contents.toString(),
-                          style: new TextStyle(
-                              color: new Color(0xff4a4a4a), fontSize: 12.0),
-                        )),
-                    //rating
-                  ],
-                ),
+                    onTap: () => {}),
               ),
-              onTap: () => {}
-            ),
+              new Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[profileImage],
+              ),
+            ],
           ),
         ),
       ],

--- a/lib/pages/session_detail_dialog.dart
+++ b/lib/pages/session_detail_dialog.dart
@@ -130,14 +130,15 @@ class SessionDetailDialog extends ModalRoute<void> {
     );
   }
 
-  double avartarSize = 160.0;
+  static const double avatarSize = 160.0;
+  static const double avatarHalfSize = avatarSize / 2;
 
   Widget get profileImage {
     return new Hero(
       tag: sessionData,
       child: new Container(
-        height: avartarSize,
-        width: avartarSize,
+        height: avatarSize,
+        width: avatarSize,
         constraints: new BoxConstraints(),
         decoration: new BoxDecoration(
           shape: BoxShape.circle,


### PR DESCRIPTION
#51 

- 다이얼로그 하단과 상단에 프로필 이미지 사이즈의 반값을 여백으로 줬습니다 (80.0)

![작업스샷](https://user-images.githubusercontent.com/24868659/54674127-1b9fef80-4b3f-11e9-9438-9883d27edbdc.png)
