### PR TITLE
[FIXED] SharedPreferences의 setString을 사용하는 method의 리턴타입에 맞춰 수정

### DIFF
--- a/lib/bloc/schedule_like_bloc.dart
+++ b/lib/bloc/schedule_like_bloc.dart
@@ -23,16 +23,18 @@ class ScheduleLikeBloc implements BlocBase {
     _likeMap.add(_map);
   }
 
-  Future addLike(String id) async {
+  Future<bool> addLike(String id) {
     _map[toBase64(id)] = true;
     _likeMap.add(_map);
-    await prefs.setString('dkf_schedule_like_map', json.encode(_map));
+    prefs.setString('dkf_schedule_like_map', json.encode(_map));
+    return prefs.commit();
   }
 
-  Future removeLike(String id) async {
+  Future<bool> removeLike(String id) {
     _map.remove(toBase64(id));
     _likeMap.add(_map);
-    await prefs.setString('dkf_schedule_like_map', json.encode(_map));
+    prefs.setString('dkf_schedule_like_map', json.encode(_map));
+    return prefs.commit();
   }
 
   @override


### PR DESCRIPTION
#71 
setString을 사용하는 함수에서
제대로 된 값을 리턴해주지 못하여 경고 메시지가 출력되는 현상을 commit 함수를 통해 수정하였습니다.
@ykc415 님 감사합니다 :)